### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This gem bundles the contents of [OwlCarousel](https://github.com/OwlFonk/OwlCar
 
 Touch enabled jQuery plugin that lets you create beautiful responsive carousel slider. [Visit Owl Carousel landing page](http://owlgraphic.com/owlcarousel).
 
-###Features:
+### Features:
 * Responsive
 * Touch Events
 * Mouse Slide Events


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
